### PR TITLE
Refactored events to also handle on_init, on_load and on_configuration changed

### DIFF
--- a/stdlib/event/event.lua
+++ b/stdlib/event/event.lua
@@ -9,17 +9,14 @@ core_events = { init = -1, load = -2, configuration_changed= -3 }
 Event = {_registry = {}}
 
 script.on_init(function()
-    debug("Event.on_init")
     Event.dispatch(core_events.init)
 end)
 
 script.on_load(function()
-    debug("Event.on_load")
     Event.dispatch(core_events.load)
 end)
 
 script.on_configuration_changed(function()
-    debug("Event.on_load")
     Event.dispatch(core_events.configuration_changed)
 end)
 

--- a/stdlib/event/event.lua
+++ b/stdlib/event/event.lua
@@ -4,20 +4,26 @@
 require 'stdlib/core'
 require 'stdlib/game'
 
-core_events = { init = -1, load = -2, configuration_changed= -3 }
 
-Event = {_registry = {}}
+Event = {
+    _registry = {},
+    core_events = { 
+        init = -1,
+        load = -2,
+        configuration_changed= -3 
+    }
+}
 
 script.on_init(function()
-    Event.dispatch(core_events.init)
+    Event.dispatch(Event.core_events.init)
 end)
 
 script.on_load(function()
-    Event.dispatch(core_events.load)
+    Event.dispatch(Event.core_events.load)
 end)
 
 script.on_configuration_changed(function()
-    Event.dispatch(core_events.configuration_changed)
+    Event.dispatch(Event.core_events.configuration_changed)
 end)
 
 --- Registers a function for a given event


### PR DESCRIPTION
Now we can use on_init, on_load and on_confugration_changed the same way:
* Event.register(core_events.init, function() 
* Event.register(core_events.load, function() 
* Event.register(core_events.configuration_changed, function() 