### PR TITLE
Gui.Event rewrite.

### DIFF
--- a/spec/gui/gui_spec.lua
+++ b/spec/gui/gui_spec.lua
@@ -1,6 +1,11 @@
 require 'stdlib/gui/gui'
 require 'spec/defines'
 
+--[[in factorio 0.13
+defines.events.on_gui_click=1
+defines.events.on_text_changed=2
+defines.events.on_checkbox_state_changed=3
+--]]
 describe('Event', function()
     before_each(function()
         _G.game = {tick = 1}
@@ -8,15 +13,106 @@ describe('Event', function()
     end)
 
     after_each(function()
-        Event._registry = {}
+        Gui.Event._registry = {}
     end)
 
-    it('.on_click should add multiple callbacks for the same element', function()
-        Gui.on_click("test_element", function() end)
-        Gui.on_click("test_element", function() end)
 
-        assert.truthy(Event._registry[defines.events.on_gui_click][1])
-        assert.truthy(Event._registry[defines.events.on_gui_click][2])
+    it('.register should fail if a nil/false event id is passed', function()
+        assert.has.errors(function() Gui.Event.register( false, "pattern1", function_a ) end)
+        assert.has.errors(function() Gui.Event.register( nil, "pattern1", function_a ) end)
+    end)
+
+    it('.register should fail if a nil/false event id is passed', function()
+        assert.has.errors(function() Gui.Event.register( 1, false, function_a ) end)
+        assert.has.errors(function() Gui.Event.register( 1, nil, function_a ) end)
+    end)
+
+    it('.register should remove handler if nil is passed as a handler', function()
+        Gui.Event.register( 1, "pattern1", function_a )
+        Gui.Event.register( 1, "pattern1", nil)
+
+        assert.is_nil( Gui.Event._registry[1] )
+    end)
+
+    it('.register should keep other patterns if different one is removed', function()
+        Gui.Event.register( 1, "pattern1", function_a )
+        Gui.Event.register( 1, "pattern2", nil)
+
+        assert.is_nil( Gui.Event._registry[1] )
+        assert.is_not_nil( Gui.Event._registry[1]["pattern1"] )
+    end)
+
+    it('.register should hook the event to script.on_event', function()
+        local s = spy.on(script, "on_event")
+        Gui.Event.register( 1, "pattern1", function_a )
+        assert.spy(s).was_called_with(1, Gui.Event.dispatch)
+    end)
+
+    it('.register should return itself', function()
+        assert.equals( Gui.Event, Gui.Event.register( 1, "pattern1", function_a ) )
+        assert.equals( Gui.Event, Gui.Event.register( 1, "pattern2", function_b ).register( 0, "pattern3", function_c ) )
+
+        assert.equals( function_a, Gui.Event._registry[1]["pattern1"] )
+        assert.equals( function_b, Gui.Event._registry[1]["pattern2"] )
+        assert.equals( function_c, Gui.Event._registry[1]["pattern3"] )
+    end)
+
+    it('.dispatch should cascade through registered handlers', function()
+        Gui.Event.register( 1, "pattern1", function_a )
+        Gui.Event.register( 1, "pattern2", function_b )
+        local event = {name = 1, tick = 9001, element={name="pattern1"}, player_index = 1}
+        local s = spy.on(test_function, "f")
+        Gui.Event.dispatch(event)
+        assert.spy(s).was_called_with(9001)
+        assert.spy(s).was_called_with(1)
+        assert.equals(1, someVariable)
+    end)
+
+    it('.dispatch should abort if a handler returns true', function()
+        Gui.Event.register( 1, "pattern1", function_a )
+        Gui.Event.register( 1, "pattern2", function_c )
+        Gui.Event.register( 1, "pattern3", function_b )
+        local event = {name = 1, tick = 9001, element={name="pattern1"}, player_index = 1}
+        local s = spy.on(test_function, "f")
+        Gui.Event.dispatch(event)
+        assert.spy(s).was_called_with(9001)
+        assert.spy(s).was_not_called_with(1)
+        assert.equals(9001, someVariable)
+    end)
+
+    it('.remove should remove the given handler from the event for pattern', function()
+        Gui.Event.register( 1, "pattern1", function_a )
+        Gui.Event.register( 1, "pattern2", function_c )
+        Gui.Event.register( 1, "pattern3", function_b )
+        Gui.Event.register( 1, "pattern4", function_c )
+
+        Gui.Event.remove( 1, "pattern4" )
+
+        assert.is_true( #Gui.Event._registry[1] == 2)
+        assert.equals( function_a, Gui.Event._registry[1]["pattern1"] )
+        assert.equals( function_b, Gui.Event._registry[1]["pattern2"] )
+    end)
+
+    it('.dispatch should print an error to connected players if a handler throws an error', function()
+        _G.game.players = { { name = 'test_player', valid = true, connected = true, print = function(msg) end } }
+        local s = spy.on(_G.game.players[1], "print")
+
+        Gui.Event.register( 1, "pattern1", function() error("should error") end)
+        Gui.Event.dispatch({name = 1, tick = 9001, element={name="pattern1"}, player_index = 1})
+        assert.spy(s).was_called()
+    end)
+
+    it('.dispatch should error when there are no connected players if a handler throws an error', function()
+        _G.game.players = { { name = 'test_player', valid = true, connected = false, print = function(msg) end } }
+        local s = spy.on(_G.game.players[1], "print")
+
+        Gui.Event.register( 0, "pattern1", function() error("should error") end)
+
+        -- verify error was raised
+        local success, err = pcall(Gui.Event.dispatch, {name = 0, tick = 9001, element={name="pattern1"}, player_index = 1})
+        assert.spy(s).was_not_called()
+        assert.is_false(success)
+        assert.is_true(err:contains("should error"))
     end)
 
     it('.on_click should fail if a nil/false gui element pattern is passed', function()
@@ -27,19 +123,5 @@ describe('Event', function()
     it('.on_click should return itself', function()
         assert.equals(Gui, Gui.on_click("test_element", function() end))
         assert.equals(Gui, Gui.on_click("test_element", function() end).on_click("test_element", function() end))
-    end)
-
-    it('.on_click should cascade through registered handlers', function()
-        local test_function = { f=function(bar) _G.foo = bar end }
-        local func_a = function(arg) test_function.f(arg.tick) end
-        local func_b = function(arg) test_function.f(arg.player_index) end
-        Gui.on_click("test_element", func_a)
-        Gui.on_click("test_element", func_b)
-        local event = {name = defines.events.on_gui_click, tick = 9001, element = { name = "test_element_foobar", valid = true }, player_index = 1}
-        local s = spy.on(test_function, "f")
-        Event.dispatch(event)
-        assert.spy(s).was_called_with(9001)
-        assert.spy(s).was_called_with(1)
-        assert.equals(1, _G.foo)
     end)
 end)

--- a/spec/gui/gui_spec.lua
+++ b/spec/gui/gui_spec.lua
@@ -1,10 +1,12 @@
 require 'stdlib/gui/gui'
 require 'spec/defines'
 
-test_function = {f=function(x) someVariable = x end}
+test_function = {f=function(x) someVariable = x end, g=function(x) someVariable = x end}
 local function_a = function(arg) test_function.f(arg.tick) end
 local function_b = function(arg) test_function.f(arg.player_index) end
 local function_c = function() return true end
+local function_d = function(arg) test_function.g(arg.tick) end
+local function_e = function(arg) test_function.g(arg.player_index) end
 local function tablelength(T)
     local count = 0
     for _ in pairs(T) do count = count + 1 end
@@ -21,114 +23,187 @@ describe('Gui', function()
         Gui.Event._registry = {}
     end)
 
-
+    --[[
+    ----.register tests
+    --]]
     it('.register should fail if a nil/false event id is passed', function()
-        assert.has.errors(function() Gui.Event.register( false, "pattern1", function_a ) end)
-        assert.has.errors(function() Gui.Event.register( nil, "pattern1", function_a ) end)
+        assert.has.errors(function() Gui.Event.register( false, "test_pattern", function_a ) end)
+        assert.has.errors(function() Gui.Event.register( nil, "test_pattern", function_a ) end)
     end)
 
-    it('.register should fail if a nil/false event id is passed', function()
+    it('.register should fail if a non-string gui_element_pattern is passed', function()
         assert.has.errors(function() Gui.Event.register( 1, false, function_a ) end)
         assert.has.errors(function() Gui.Event.register( 1, nil, function_a ) end)
+        assert.has.errors(function() Gui.Event.register( 1, 5, function_a ) end)
+        assert.has.errors(function() Gui.Event.register( 1, {4}, function_a ) end)
+    end)
+
+    it('.register should register a handler for a given pattern', function()
+        Gui.Event.register( 1, "test_pattern", function_a )
+
+        assert.is_not_nil( Gui.Event._registry[1] )
+        assert.equals( function_a, Gui.Event._registry[1]["test_pattern"] )
+    end)
+
+    it('.register should replace a handler when given a new one for a given pattern', function()
+        Gui.Event.register( 1, "test_pattern", function_a )
+        Gui.Event.register( 1, "test_pattern", function_b )
+
+        assert.is_not_nil( Gui.Event._registry[1] )
+        assert.equals( function_b, Gui.Event._registry[1]["test_pattern"] )
     end)
 
     it('.register should remove handler if nil is passed as a handler', function()
-        Gui.Event.register( 1, "pattern1", function_a )
-        Gui.Event.register( 1, "pattern1", nil)
+        Gui.Event.register( 1, "test_pattern", function_a )
+        Gui.Event.register( 1, "test_pattern", nil)
 
         assert.is_nil( Gui.Event._registry[1] )
     end)
 
-    it('.register should keep other patterns if different one is removed', function()
-        Gui.Event.register( 1, "pattern1", function_a )
-        Gui.Event.register( 1, "pattern2", nil)
+    it('.register should keep all existing patterns when a new one is registered', function()
+        Gui.Event.register( 1, "test_pattern", function_a )
+        Gui.Event.register( 1, "test_pattern2", function_b )
+        Gui.Event.register( 1, "test_pattern3", function_c)
 
         assert.is_not_nil( Gui.Event._registry[1] )
-        assert.is_not_nil( Gui.Event._registry[1]["pattern1"] )
-        assert.is_nil( Gui.Event._registry[1]["pattern2"] )
+        assert.equals( function_c, Gui.Event._registry[1]["test_pattern3"] )
+        assert.equals( function_b, Gui.Event._registry[1]["test_pattern2"] )
+        assert.equals( function_a, Gui.Event._registry[1]["test_pattern"] )
     end)
 
-    --failure
-    it('.register should hook the event to script.on_event', function()
-        local s = spy.on(script, "on_event")
-        Gui.Event.register( 1, "pattern1", function_a )
+    it('.register should keep all existing patterns when a one is removed', function()
+        Gui.Event.register( 1, "test_pattern", function_a )
+        Gui.Event.register( 1, "test_pattern2", function_b )
+        Gui.Event.register( 1, "test_pattern3", function_c )
+        Gui.Event.register( 1, "test_pattern2", nil)
+
+        assert.is_not_nil( Gui.Event._registry[1] )
+        assert.equals( function_c, Gui.Event._registry[1]["test_pattern3"] )
+        assert.is_nil( Gui.Event._registry[1]["test_pattern2"] )
+        assert.equals( function_a, Gui.Event._registry[1]["test_pattern"] )
+    end)
+
+    it('.register should pass the event Event.register for final registration', function()
+        local s = spy.on(Event, "register")
+        Gui.Event.register( 1, "test_pattern", function_a )
+        assert.spy(s).was_called()
         assert.spy(s).was_called_with(1, Gui.Event.dispatch)
     end)
 
     it('.register should return itself', function()
-        assert.equals( Gui.Event, Gui.Event.register( 1, "pattern1", function_a ) )
-        assert.equals( Gui.Event, Gui.Event.register( 1, "pattern2", function_b ).register( 1, "pattern3", function_c ) )
+        assert.equals( Gui.Event, Gui.Event.register( 1, "test_pattern", function_a ) )
+        assert.equals( Gui.Event, Gui.Event.register( 1, "test_pattern2", function_b ).register( 1, "test_pattern3", function_c ) )
 
-        assert.equals( function_a, Gui.Event._registry[1]["pattern1"] )
-        assert.equals( function_b, Gui.Event._registry[1]["pattern2"] )
-        assert.equals( function_c, Gui.Event._registry[1]["pattern3"] )
+        assert.equals( function_a, Gui.Event._registry[1]["test_pattern"] )
+        assert.equals( function_b, Gui.Event._registry[1]["test_pattern2"] )
+        assert.equals( function_c, Gui.Event._registry[1]["test_pattern3"] )
     end)
 
-    --failure
-    it('.dispatch should cascade through registered handlers', function()
-        Gui.Event.register( 1, "pattern1", function_a )
-        Gui.Event.register( 1, "pattern12", function_b )
-        local event = {name = 1, tick = 9001, element={name="pattern123"}, player_index = 1}
+    --[[
+    ----.dispath methods of use
+    --]]
+    it('.dispath should fail if a nil/false event id is passed', function()
+        assert.has.errors(function() Gui.Event.dispath( false ) end)
+        assert.has.errors(function() Gui.Event.dispath( nil ) end)
+    end)
+
+    it('.dispatch should call all registered handlers for matching patterns', function()
+        Gui.Event.register( 1, "test_pattern", function_a )
+        Gui.Event.register( 1, "test_pattern1", function_b )
+        Gui.Event.register( 1, "_pa", function_d )
+        Gui.Event.register( 1, "12", function_e )
+        local event = {name = 1, tick = 9001, element={name="test_pattern12",valid=true}, player_index = 1}
         local s = spy.on(test_function, "f")
+        local s2 = spy.on(test_function, "g")
         Gui.Event.dispatch(event)
         assert.spy(s).was_called_with(9001)
         assert.spy(s).was_called_with(1)
-        assert.equals(1, someVariable)
+        assert.spy(s2).was_called_with(9001)
+        assert.spy(s2).was_called_with(1)
     end)
 
-    it('.remove should remove the given handler from the event for pattern', function()
-        Gui.Event.register( 1, "pattern1", function_a )
-        Gui.Event.register( 1, "pattern2", function_b )
-        Gui.Event.register( 1, "pattern3", function_b )
-        Gui.Event.register( 1, "pattern2", function_c )
-
-        Gui.Event.remove( 1, "pattern2" )
-
-        assert.is_true( tablelength(Gui.Event._registry[1]) == 2)
-        assert.equals( function_a, Gui.Event._registry[1]["pattern1"] )
-        assert.equals( function_b, Gui.Event._registry[1]["pattern3"] )
-        assert.is_nil( Gui.Event._registry[1]["pattern2"] )
-
+    it('.dispatch should not call handlers for non-matching patterns', function()
+        Gui.Event.register( 1, "test-pattern", function_a )
+        Gui.Event.register( 1, "%asd$", function_a )
+        Gui.Event.register( 1, "\"", function_a )
+        Gui.Event.register( 1, "123", function_a )
+        local event = {name = 1, tick = 9001, element={name="test_pattern12",valid=true}, player_index = 1}
+        local s = spy.on(test_function, "f")
+        Gui.Event.dispatch(event)
+        assert.spy(s).was_not_called()
     end)
 
-    --failure
     it('.dispatch should print an error to connected players if a handler throws an error', function()
         _G.game.players = { { name = 'test_player', valid = true, connected = true, print = function(msg) end } }
         local s = spy.on(_G.game.players[1], "print")
 
-        Gui.Event.register( 1, "pattern1", function() error("should error") end)
-        Gui.Event.dispatch({name = 1, tick = 9001, element={name="pattern1"}, player_index = 1})
-        assert.is_not_nil( Gui.Event._registry[1]["pattern1"] )
+        Gui.Event.register( 1, "test_pattern", function() error("should error") end)
+        assert.is_not_nil( Gui.Event._registry[1]["test_pattern"] )
+
+        Gui.Event.dispatch({name = 1, tick = 9001, element={name="test_pattern",valid=true}, player_index = 1})
         assert.spy(s).was_called()
     end)
 
-    it('.on_click should fail if a nil/false gui element pattern is passed', function()
-        assert.has.errors(function() Gui.on_click(false) end)
-        assert.has.errors(function() Gui.on_click() end)
+    --[[
+    ----.remove methods of use
+    --]]
+    it('.remove should fail if a nil/false event id is passed', function()
+        assert.has.errors(function() Gui.Event.remove( false, "test_pattern" ) end)
+        assert.has.errors(function() Gui.Event.remove( nil, "test_pattern" ) end)
     end)
 
+    it('.remove should fail if a non-string gui_element_pattern is passed', function()
+        assert.has.errors(function() Gui.Event.remove( 1, false, "test_pattern" ) end)
+        assert.has.errors(function() Gui.Event.remove( 1, nil, "test_pattern" ) end)
+        assert.has.errors(function() Gui.Event.remove( 1, 5, "test_pattern" ) end)
+        assert.has.errors(function() Gui.Event.remove( 1, {4}, "test_pattern" ) end)
+    end)
+
+    it('.remove should remove only the handler of given pattern', function()
+        Gui.Event.register( 1, "test_pattern", function_a )
+        Gui.Event.register( 1, "test_pattern2", function_b )
+        Gui.Event.register( 1, "test_pattern3", function_c )
+
+        Gui.Event.remove( 1, "test_pattern2" )
+
+        assert.is_true( tablelength(Gui.Event._registry[1]) == 2)
+        assert.equals( function_a, Gui.Event._registry[1]["test_pattern"] )
+        assert.equals( function_c, Gui.Event._registry[1]["test_pattern3"] )
+        assert.is_nil( Gui.Event._registry[1]["test_pattern2"] )
+    end)
+
+    --[[
+    ----.on_click methods of use
+    --]]
     it('.on_click should return itself', function()
-        assert.equals(Gui, Gui.on_click("test_element", function() end))
-        assert.equals(Gui, Gui.on_click("test_element", function() end).on_click("test_element", function() end))
+        assert.equals(Gui, Gui.on_click("test_pattern", function() end))
+        assert.equals(Gui, Gui.on_click("test_pattern", function() end).on_click("test_pattern", function() end))
     end)
 
-    it('.on_checked_state_changed should fail if a nil/false gui element pattern is passed', function()
-        assert.has.errors(function() Gui.on_checked_state_changed(false) end)
-        assert.has.errors(function() Gui.on_checked_state_changed() end)
+    it('.on_click should pass the event to Gui.Event.register for registration', function()
+        local s = spy.on(Gui.Event, "register")
+        Gui.on_click( "test_pattern", function_a )
+        assert.spy(s).was_called()
+        assert.spy(s).was_called_with(defines.events.on_gui_click, "test_pattern", function_a)
     end)
 
-    it('.on_checked_state_changed should return itself', function()
-        assert.equals(Gui, Gui.on_checked_state_changed("test_element", function() end))
-        assert.equals(Gui, Gui.on_checked_state_changed("test_element", function() end).on_checked_state_changed("test_element", function() end))
+    --[[
+    ----.on_checked_state_changed methods of use
+    --]]
+    it('.on_checked_state_changed should pass the event to Gui.Event.register for registration', function()
+        local s = spy.on(Gui.Event, "register")
+        Gui.on_checked_state_changed( "test_pattern", function_a )
+        assert.spy(s).was_called()
+        assert.spy(s).was_called_with(defines.events.on_gui_checked_state_changed, "test_pattern", function_a)
     end)
 
-    it('.on_text_changed should fail if a nil/false gui element pattern is passed', function()
-        assert.has.errors(function() Gui.on_text_changed(false) end)
-        assert.has.errors(function() Gui.on_text_changed() end)
-    end)
-
-    it('.on_text_changed should return itself', function()
-        assert.equals(Gui, Gui.on_text_changed("test_element", function() end))
-        assert.equals(Gui, Gui.on_text_changed("test_element", function() end).on_text_changed("test_element", function() end))
+    --[[
+    ----.on_text_changed methods of use
+    --]]
+    it('.on_text_changed should pass the event to Gui.Event.register for registration', function()
+        local s = spy.on(Gui.Event, "register")
+        Gui.on_text_changed( "test_pattern", function_a )
+        assert.spy(s).was_called()
+        assert.spy(s).was_called_with(defines.events.on_gui_text_changed, "test_pattern", function_a)
     end)
 end)

--- a/stdlib/gui/gui.lua
+++ b/stdlib/gui/gui.lua
@@ -18,13 +18,13 @@ function Gui.Event.register(event, gui_element_pattern, handler)
     fail_if_missing(event, "missing event name argument")
     fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
 
+    if type(gui_element_pattern) ~= "string" then
+        error("gui_element_pattern argument must be a string")
+    end
+
     if handler == nil then
         Gui.Event.remove(event, gui_element_pattern)
         return Gui.Event
-    end
-
-    if type(gui_element_pattern) ~= "string" then
-        gui_element_pattern = tostring(gui_element_pattern)
     end
 
     if not Gui.Event._registry[event] then
@@ -68,6 +68,11 @@ function Gui.Event.remove(event, gui_element_pattern)
     fail_if_missing(event, "missing event argument")
     fail_if_missing(gui_element_pattern, "missing gui_element_pattern argument")
 
+    if type(gui_element_pattern) ~= "string" then
+        error("gui_element_pattern argument must be a string")
+    end
+
+
     local function tablelength(T)
         local count = 0
         for _ in pairs(T) do count = count + 1 end
@@ -92,10 +97,7 @@ end
 -- @param handler Function to call when gui element is clicked
 -- @return #Gui
 function Gui.on_click(gui_element_pattern, handler)
-    fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
-
     Gui.Event.register(defines.events.on_gui_click, gui_element_pattern, handler)
-
     return Gui
 end
 
@@ -104,10 +106,7 @@ end
 -- @param handler Function to call when gui element checked state changes
 -- @return #Gui
 function Gui.on_checked_state_changed(gui_element_pattern, handler)
-    fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
-
     Gui.Event.register(defines.events.on_gui_checked_state_changed, gui_element_pattern, handler)
-
     return Gui
 end
 
@@ -116,9 +115,6 @@ end
 -- @param handler Function to call when gui element text changes
 -- @return #Gui
 function Gui.on_text_changed(gui_element_pattern, handler)
-    fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
-
     Gui.Event.register(defines.events.on_gui_text_changed, gui_element_pattern, handler)
-
     return Gui
 end

--- a/stdlib/gui/gui.lua
+++ b/stdlib/gui/gui.lua
@@ -64,11 +64,17 @@ function Gui.Event.remove(event, gui_element_pattern)
     fail_if_missing(event, "missing event argument")
     fail_if_missing(gui_element_pattern, "missing gui_element_pattern argument")
 
+    local function tablelength(T)
+        local count = 0
+        for _ in pairs(T) do count = count + 1 end
+        return count
+    end
+
     if Gui.Event._registry[event] then
         if Gui.Event._registry[event][gui_element_pattern] then
-            table.remove(Gui.Event._registry[event], gui_element_pattern)
+            Gui.Event._registry[event][gui_element_pattern] = nil
         end
-        if #Gui.Event._registry[event] == 0 then
+        if tablelength(Gui.Event._registry[event]) == 0 then
             Gui.Event._registry[event] = nil
             script.on_event(event, nil)
         end

--- a/stdlib/gui/gui.lua
+++ b/stdlib/gui/gui.lua
@@ -53,7 +53,10 @@ function Gui.Event.dispatch(event)
                 if event.name == defines.events.on_gui_text_changed then new_event.text = gui_element.text end
                 local success, err = pcall(handler, new_event)
                 if not success then
-                    Game.print_all(err)
+                    if Game.print_all(err) == 0 then
+                        -- no players received the message, force a real error so someone notices
+                        error(err)
+                    end
                 end
             end
         end

--- a/stdlib/gui/gui.lua
+++ b/stdlib/gui/gui.lua
@@ -4,6 +4,81 @@
 require 'stdlib/event/event'
 
 Gui = {}
+-- Factorio's gui events are so monolithic we need a special event system for it.
+Gui.Event = {
+    _registry = {}
+}
+
+--- Registers a function for a given event and matching gui element pattern
+-- @param event Valid values are defines.event.on_gui_*
+-- @param gui_element_pattern the name or string regular expression to match the gui element
+-- @param handler Function to call when event is triggered
+-- @return #Gui.Event
+function Gui.Event.register(event, gui_element_pattern, handler)
+    fail_if_missing(event, "missing event name argument")
+    fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
+    fail_if_missing(handler, "missing function handler argument")
+
+    if type(gui_element_pattern) == "string" then
+        gui_element_pattern = tostring(gui_element_pattern)
+    end
+
+    if not Gui.Event._registry[event] then
+        Gui.Event._registry[event] = {}
+    end
+    Gui.Event._registry[event][gui_element_pattern] = handler;
+
+    -- Use custom Gui event dispatcher to pass off the event to the correct sub-handler
+    Event.register(event, Gui.Event.dispatch)
+    end
+    return Gui.Event
+end
+
+--- Calls the registered handlers
+-- @param event LuaEvent as created by game.raise_event
+function Gui.Event.dispatch(event)
+    fail_if_missing(event, "missing event argument")
+
+    local gui_element = event.element
+    if gui_element and gui_element.valid then
+        for gui_element_pattern, handler in pairs(Gui.Event._registry[event.name]) do
+            local match_str = string.match(gui_element.name, gui_element_pattern)
+            if match_str ~= nil then
+                local new_event = { tick = event.tick, name = event.name, _handler = handler, match = match_str, element = gui_element, player_index = event.player_index , _event = event}
+                if event.name == defines.events.on_gui_checked_state_changed then new_event.state = gui_element.state end
+                if event.name == defines.events.on_gui_text_changed then new_event.text = gui_element.text end
+                local success, err = pcall(handler, new_event)
+                if not success then
+                    Game.print_all(err)
+                    return err
+                end
+                -- if success, err is the std return result
+                return err
+            end
+        end
+    end
+end
+
+--- Removes the handler with matching gui element pattern from the event
+-- @param event Valid values are defines.event.on_gui_*
+-- @param gui_element_pattern the name or string regular expression to remove the handler for
+-- @return #Gui
+function Gui.Event.remove(event, gui_element_pattern)
+    fail_if_missing(event, "missing event argument")
+    fail_if_missing(gui_element_pattern, "missing gui_element_pattern argument")
+
+    if Gui.Event._registry[event] then
+        if Gui.Event._registry[event][gui_element_pattern] then
+            table.remove(Gui.Event._registry[event], gui_element_pattern)
+        end
+        if #Gui.Event._registry[event] == 0 then
+            Gui.Event._registry[event] = nil
+            script.on_event(event, nil)
+        end
+    end
+    return Gui
+end
+
 
 --- Registers a function for a given gui element name or pattern when the element is clicked
 -- @param gui_element_pattern the name or string regular expression to match the gui element
@@ -13,22 +88,33 @@ function Gui.on_click(gui_element_pattern, handler)
     fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
     fail_if_missing(handler, "missing function handler argument")
 
-    Event.register(defines.events.on_gui_click, function(event)
-        local gui_element = event.element
-        if gui_element and gui_element.valid then
-            local match_str = string.match(gui_element.name, gui_element_pattern)
-            if match_str ~= nil then
-                local new_event = { tick = event.tick, name = event.name, _handler = handler, match = match_str, element = gui_element, player_index = event.player_index }
-                local success, err = pcall(handler, event)
-                if not success then
-                    Game.print_all(err)
-                    return err
-                end
-                -- if success, err is the std return result
-                return err
-            end
-        end
-    end)
+    Gui.Event.register(defines.events.on_gui_click, gui_element_pattern, handler)
+
+    return Gui
+end
+
+--- Registers a function for a given gui element name or pattern when the element checked state changes
+-- @param gui_element_pattern the name or string regular expression to match the gui element
+-- @param handler Function to call when gui element checked state changes
+-- @return #Gui
+function Gui.on_checked_state_changed(gui_element_pattern, handler)
+    fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
+    fail_if_missing(handler, "missing function handler argument")
+
+    Gui.Event.register(defines.events.on_gui_checked_state_changed, gui_element_pattern, handler)
+
+    return Gui
+end
+
+--- Registers a function for a given gui element name or pattern when the element text changes
+-- @param gui_element_pattern the name or string regular expression to match the gui element
+-- @param handler Function to call when gui element text changes
+-- @return #Gui
+function Gui.on_text_changed(gui_element_pattern, handler)
+    fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
+    fail_if_missing(handler, "missing function handler argument")
+
+    Gui.Event.register(defines.events.on_gui_text_changed, gui_element_pattern, handler)
 
     return Gui
 end

--- a/stdlib/gui/gui.lua
+++ b/stdlib/gui/gui.lua
@@ -53,10 +53,7 @@ function Gui.Event.dispatch(event)
                 if event.name == defines.events.on_gui_text_changed then new_event.text = gui_element.text end
                 local success, err = pcall(handler, new_event)
                 if not success then
-                    if Game.print_all(err) == 0 then
-                        -- no players received the message, force a real error so someone notices
-                        error(err)
-                    end
+                    Game.print_all(err)
                 end
             end
         end

--- a/stdlib/gui/gui.lua
+++ b/stdlib/gui/gui.lua
@@ -50,10 +50,7 @@ function Gui.Event.dispatch(event)
                 local success, err = pcall(handler, new_event)
                 if not success then
                     Game.print_all(err)
-                    return err
                 end
-                -- if success, err is the std return result
-                return err
             end
         end
     end

--- a/stdlib/gui/gui.lua
+++ b/stdlib/gui/gui.lua
@@ -17,16 +17,20 @@ Gui.Event = {
 function Gui.Event.register(event, gui_element_pattern, handler)
     fail_if_missing(event, "missing event name argument")
     fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
-    fail_if_missing(handler, "missing function handler argument")
 
-    if type(gui_element_pattern) == "string" then
+    if handler == nil then
+        Gui.Event.remove(event, gui_element_pattern)
+        return Gui.Event
+    end
+
+    if type(gui_element_pattern) ~= "string" then
         gui_element_pattern = tostring(gui_element_pattern)
     end
 
     if not Gui.Event._registry[event] then
         Gui.Event._registry[event] = {}
     end
-    Gui.Event._registry[event][gui_element_pattern] = handler;
+    Gui.Event._registry[event][gui_element_pattern] = handler
 
     -- Use custom Gui event dispatcher to pass off the event to the correct sub-handler
     Event.register(event, Gui.Event.dispatch)
@@ -59,7 +63,7 @@ end
 --- Removes the handler with matching gui element pattern from the event
 -- @param event Valid values are defines.event.on_gui_*
 -- @param gui_element_pattern the name or string regular expression to remove the handler for
--- @return #Gui
+-- @return #Gui.Event
 function Gui.Event.remove(event, gui_element_pattern)
     fail_if_missing(event, "missing event argument")
     fail_if_missing(gui_element_pattern, "missing gui_element_pattern argument")
@@ -79,7 +83,7 @@ function Gui.Event.remove(event, gui_element_pattern)
             script.on_event(event, nil)
         end
     end
-    return Gui
+    return Gui.Event
 end
 
 
@@ -89,7 +93,6 @@ end
 -- @return #Gui
 function Gui.on_click(gui_element_pattern, handler)
     fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
-    fail_if_missing(handler, "missing function handler argument")
 
     Gui.Event.register(defines.events.on_gui_click, gui_element_pattern, handler)
 
@@ -102,7 +105,6 @@ end
 -- @return #Gui
 function Gui.on_checked_state_changed(gui_element_pattern, handler)
     fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
-    fail_if_missing(handler, "missing function handler argument")
 
     Gui.Event.register(defines.events.on_gui_checked_state_changed, gui_element_pattern, handler)
 
@@ -115,7 +117,6 @@ end
 -- @return #Gui
 function Gui.on_text_changed(gui_element_pattern, handler)
     fail_if_missing(gui_element_pattern, "missing gui name or pattern argument")
-    fail_if_missing(handler, "missing function handler argument")
 
     Gui.Event.register(defines.events.on_gui_text_changed, gui_element_pattern, handler)
 

--- a/stdlib/gui/gui.lua
+++ b/stdlib/gui/gui.lua
@@ -30,7 +30,7 @@ function Gui.Event.register(event, gui_element_pattern, handler)
 
     -- Use custom Gui event dispatcher to pass off the event to the correct sub-handler
     Event.register(event, Gui.Event.dispatch)
-    end
+
     return Gui.Event
 end
 


### PR DESCRIPTION
Allows for creating per "element" events for on_click, on_state_changed, on_text_changed

Now that I'm making the pull request should the Gui.Event be split from stdlib/gui/gui.lua into a file of it's own? stdlib/gui/event.lua for example?