### PR TITLE
Quick Fix for set_data error

### DIFF
--- a/stdlib/entity/entity.lua
+++ b/stdlib/entity/entity.lua
@@ -145,7 +145,7 @@ function Entity._are_equal(entity_a, entity_b)
     return entity_a == entity_b
   elseif entity_a == entity_b then
     return true
-  elseif entity_a.equals ~= nil then
+  elseif Entity.has(entity_a, "equals") and entity_a.equals ~= nil then
     return entity_a.equals(entity_b)
   else
     return false


### PR DESCRIPTION
Not sure if I was just using it wrong, but `set_data` was complaining about the `equals` field not existing for any setting of data after the first (each set was on a different entity).
The `has` method is a far more robust way of checking for existence, though I have left the original check just in case.