### PR TITLE
added option to Logger.new to use log() if game isn't available

### DIFF
--- a/spec/log/logger_spec.lua
+++ b/spec/log/logger_spec.lua
@@ -60,6 +60,21 @@ describe('Logger Spec', function()
             l.log('foo3')
             assert.spy(s).was_called_with('logs/spec/test.log', '00:01:01: foo3\n', true)
         end)
+        
+        it('uses log() if _G.game is not available', function()
+          _G["game"] = nil
+          _G["log"] = function() end
+          local s = spy.on(_G, 'log')
+          
+          local l = Logger.new('spec', 'test', true, { use_log = true })
+          l.log('foo')
+          assert.spy(s).was_called_with('spec/test: foo')
+          assert.equals('00:00:00: foo\n', l.buffer[1])
+          _G["game"] = { tick = 0, write_file = function() end }
+          local s2 = spy.on(_G["game"], 'write_file')
+          l.log('foo2')
+          assert.spy(s2).was_called_with('logs/spec/test.log', '00:00:00: foo\n00:00:00: foo2\n', false)
+        end)
     end)
 
     describe('Logger.write', function()

--- a/spec/log/logger_spec.lua
+++ b/spec/log/logger_spec.lua
@@ -60,21 +60,37 @@ describe('Logger Spec', function()
             l.log('foo3')
             assert.spy(s).was_called_with('logs/spec/test.log', '00:01:01: foo3\n', true)
         end)
-        
-        it('uses log() if _G.game is not available', function()
-          _G["game"] = nil
-          _G["log"] = function() end
-          local s = spy.on(_G, 'log')
-          
-          local l = Logger.new('spec', 'test', true, { use_log = true })
-          l.log('foo')
-          assert.spy(s).was_called_with('spec/test: foo')
-          assert.equals('00:00:00: foo\n', l.buffer[1])
-          _G["game"] = { tick = 0, write_file = function() end }
-          local s2 = spy.on(_G["game"], 'write_file')
-          l.log('foo2')
-          assert.spy(s2).was_called_with('logs/spec/test.log', '00:00:00: foo\n00:00:00: foo2\n', false)
+
+        it('uses log() if _G.script is not available', function()
+            _G["game"] = nil
+            _G["script"] = false
+            _G["log"] = function() end
+            local spyLog = spy.on(_G, 'log')
+
+            local l = Logger.new('spec', 'test', true, { use_log = true })
+            l.log('foo')
+            assert.spy(spyLog).was_called_with('spec/test: foo')
+            assert.falsy(l.buffer[1]) --do not buffer in data stage
         end)
+
+        it('buffers messages when _G.script is available', function()
+            _G["game"] = nil
+            _G["script"] = true
+            _G["log"] = function() end
+
+            local l = Logger.new('spec', 'test', true)
+            local spyLog = spy.on(_G, 'log')
+            l.log('no game')
+            assert.spy(spyLog).was_not_called()
+            assert.equals('00:00:00: no game\n', l.buffer[1])
+            
+            _G["game"] = { tick = 0, write_file = function() end }
+            local s2 = spy.on(_G["game"], 'write_file')
+            l.log('got game')
+            assert.spy(s2).was_called_with('logs/spec/test.log', '00:00:00: no game\n00:00:00: got game\n', false)
+            assert.falsy(l.buffer[1])
+        end)
+
     end)
 
     describe('Logger.write', function()

--- a/stdlib/log/logger.lua
+++ b/stdlib/log/logger.lua
@@ -13,6 +13,8 @@ Logger = {} --luacheck: allow defined top
 -- file_extension -- a string that overides the default 'log' file extension.
 -- force_append -- each time a logger is created, it will always append, instead of
 -- -- the default behavior, which is to write out a new file, then append
+-- use_log -- whether to use log() if game.write_file isn't available, ignores other
+-- -- options in that case. Once game.write_file is available it stops writing to log().
 -- </code>
 --
 -- @usage
@@ -49,6 +51,7 @@ function Logger.new(mod_name, log_name, debug_mode, options)
         log_ticks = options.log_ticks or false, -- whether to add the ticks in the timestamp, default false
         file_extension = options.file_extension or 'log', -- extension of the file, default: log
         force_append = options.force_append or false, -- append the file on first write, default: false
+        use_log = options.use_log or false, -- use log() if game.write_file isn't available, ignores other options in that case, default: false
     }
     Logger.file_name = 'logs/' .. Logger.mod_name .. '/' .. Logger.log_name .. '.' .. Logger.options.file_extension
     Logger.ever_written = Logger.options.force_append
@@ -76,6 +79,9 @@ function Logger.new(mod_name, log_name, debug_mode, options)
                 return Logger.write()
             end
         else
+            if Logger.options.use_log then
+                log(format("%s/%s: %s", Logger.mod_name, Logger.log_name, msg))
+            end
             table.insert(Logger.buffer, format("00:00:00: %s\n", msg))
         end
         return false

--- a/stdlib/log/logger.lua
+++ b/stdlib/log/logger.lua
@@ -13,8 +13,6 @@ Logger = {} --luacheck: allow defined top
 -- file_extension -- a string that overides the default 'log' file extension.
 -- force_append -- each time a logger is created, it will always append, instead of
 -- -- the default behavior, which is to write out a new file, then append
--- use_log -- whether to use log() if game.write_file isn't available, ignores other
--- -- options in that case. Once game.write_file is available it stops writing to log().
 -- </code>
 --
 -- @usage
@@ -51,7 +49,6 @@ function Logger.new(mod_name, log_name, debug_mode, options)
         log_ticks = options.log_ticks or false, -- whether to add the ticks in the timestamp, default false
         file_extension = options.file_extension or 'log', -- extension of the file, default: log
         force_append = options.force_append or false, -- append the file on first write, default: false
-        use_log = options.use_log or false, -- use log() if game.write_file isn't available, ignores other options in that case, default: false
     }
     Logger.file_name = 'logs/' .. Logger.mod_name .. '/' .. Logger.log_name .. '.' .. Logger.options.file_extension
     Logger.ever_written = Logger.options.force_append
@@ -79,10 +76,11 @@ function Logger.new(mod_name, log_name, debug_mode, options)
                 return Logger.write()
             end
         else
-            if Logger.options.use_log then
+            if _G.script then --buffer when a save is loaded but _G.game isn't available
+                table.insert(Logger.buffer, format("00:00:00: %s\n", msg))
+            else --log in data stage
                 log(format("%s/%s: %s", Logger.mod_name, Logger.log_name, msg))
             end
-            table.insert(Logger.buffer, format("00:00:00: %s\n", msg))
         end
         return false
     end


### PR DESCRIPTION
Can be used during the data stage and outside of functions in
control.lua. When game is available the first Logger:log() writes the
buffered messages from log()

adresses #81 