### PR TITLE
Add test cases for stdlib.event.opened

### DIFF
--- a/spec/event/opened_spec.lua
+++ b/spec/event/opened_spec.lua
@@ -1,7 +1,139 @@
-require 'spec/setup/defines'
-require 'stdlib/event/event'
---require 'stdlib.event.opened'
+local World = require "spec/setup/world"
+World.Debug.allow_print = true
 
-describe('event.opened', function()
+describe("event.opened",
+    function()
 
-end)
+        before_each(
+            function()
+                World.open()
+            end
+        )
+
+        after_each(
+            function()
+                World.close()
+            end
+        )
+
+        it("should allow itself to be loaded at startup time",
+            function()
+                require("stdlib/event/opened")
+            end
+        )
+
+        it("should register handlers for on_tick & init_and_config events",
+            function()
+                require("stdlib/event/event")
+                local register_spy = spy.on(Event, "register")
+                require("stdlib/event/opened")
+                local match = require("luassert.match")
+                assert.spy(register_spy).was_called_with(defines.events.on_tick, match.is_function())
+                assert.spy(register_spy).was_called_with(Event.core_events.init_and_config, match.is_function())
+                assert.is_same(3, table.count_keys(Event._registry))
+                assert.is_true(#Event._registry[Event.core_events.init] == 1)
+                assert.is_true(#Event._registry[Event.core_events.configuration_changed] == 1)
+                assert.is_true(#Event._registry[defines.events.on_tick] == 1)
+            end
+        )
+
+        it("should create global._opened_guis table on init_and_config",
+            function()
+                require("stdlib/event/opened")
+                _G.global = { }
+                Event.dispatch({name = Event.core_events.init})
+                assert.is_table(_G.global._opened_guis)
+                _G.global = { }
+                Event.dispatch({name = Event.core_events.configuration_changed})
+                assert.is_table(_G.global._opened_guis)
+            end
+        )
+
+        it("should create new on_player_opened & on_player_closed events",
+            function()
+                local generate_event_name_spy = spy.on(_G.script, "generate_event_name")
+                require("stdlib/event/opened")
+                assert.spy(generate_event_name_spy).was_called(2)
+            end
+        )
+
+        it("should create global._opened_guis[player.index] on_tick",
+            function()
+                require("stdlib/event/opened")
+                World.init()
+                local num_players = 3
+                World.create_players(num_players)
+                World.update(30)
+                for i = 1,num_players do
+                    assert.is_table(_G.global._opened_guis[i])
+                end
+            end
+        )
+
+        it("should raise on_player_opened and then on_player_closed for type = 'self'",
+            function()
+                local Game = require("stdlib/game")
+                require("stdlib/event/opened")
+                local functions = {opened_handler = function(event) return event end, closed_handler = function(event) return event end}
+                local opened_spy = spy.on(functions, "opened_handler")
+                local closed_spy = spy.on(functions, "closed_handler")
+                Event.register(Event.on_player_opened, functions.opened_handler)
+                Event.register(Event.on_player_closed, functions.closed_handler)
+                World.init()
+                local num_players = 3
+                World.create_players(num_players, { opened_self = true })
+                World.update(30)
+                for player_index = 1, num_players do
+                    assert.spy(opened_spy).was_called_with({name = Event.on_player_opened, player_index = player_index, type = "self", tick = _G.game.tick})
+                    Game.get_player(player_index).opened_self = false
+                end
+                World.update(30)
+                for player_index = 1, num_players do
+                    assert.spy(closed_spy).was_called_with({name = Event.on_player_closed, player_index = player_index, type = "self", tick = _G.game.tick})
+                    Game.get_player(player_index).opened_self = true
+                end
+            end
+        )
+
+        it("should raise on_player_opened and then on_player_closed for type = 'entity'",
+            function()
+                local Game = require("stdlib/game")
+                require("stdlib/event/opened")
+                local functions = {opened_handler = function(event) return event end, closed_handler = function(event) return event end}
+                local opened_spy = spy.on(functions, "opened_handler")
+                local closed_spy = spy.on(functions, "closed_handler")
+                Event.register(Event.on_player_opened, functions.opened_handler)
+                Event.register(Event.on_player_closed, functions.closed_handler)
+                World.init()
+                local num_players = 3
+                World.create_players(num_players, { opened = {valid = true} })
+                World.update(30)
+                for player_index = 1, num_players do
+                    assert.spy(opened_spy).was_called_with({
+                            name = Event.on_player_opened,
+                            player_index = player_index,
+                            type = "entity",
+                            entity = Game.get_player(player_index).opened,
+                            tick = _G.game.tick
+                        }
+                    )
+                end
+                for player_index = 1, num_players do
+                    Game.get_player(player_index).opened.valid = false
+                end
+                World.update(30)
+                for player_index = 1, num_players do
+                    assert.spy(closed_spy).was_called_with({
+                            name = Event.on_player_closed,
+                            player_index = player_index,
+                            type = "entity",
+                            entity = Game.get_player(player_index).opened,
+                            tick = _G.game.tick
+                        }
+                    )
+                end
+            end
+        )
+
+    end
+)

--- a/stdlib/area/area.lua
+++ b/stdlib/area/area.lua
@@ -1,4 +1,5 @@
 --- Tools for working with bounding boxes.
+-- The tables passed into the Area functions are mutated in-place.
 -- @module Area
 -- @usage local Area = require('stdlib/area/area')
 -- @see Position

--- a/stdlib/area/position.lua
+++ b/stdlib/area/position.lua
@@ -1,4 +1,5 @@
 --- Tools for working with `<x,y>` coordinates.
+-- The tables passed into the Position functions are mutated in-place.
 -- @module Position
 -- @usage local Position = require('stdlib/area/position')
 -- @see Area

--- a/stdlib/entity/entity.lua
+++ b/stdlib/entity/entity.lua
@@ -148,11 +148,12 @@ end
 -- from @{https://github.com/aubergine10/lifecycle-events lifecycle-events}
 -- <br>Used for raising `on_built and on_died` events for other mods
 
---- Destroy an entity by first raising the event. Some entities can't be destroyed 'rails with trains on them'
--- <p>In these cases the event will be still be raised as there is no way to find out if something is indestructible temporarily
--- @tparam LuaEntity entity The entity to be destroyed
+--- Destroy an entity by first raising the event.
+--> Some entities can't be destroyed, such as the rails with trains on them.
+-- In these cases, the event will still be raised as there is no way to find out if something is indestructible temporarily.
+-- @tparam LuaEntity entity the entity to be destroyed
 -- @tparam[opt] table event additional data to pass to the event handler
--- @treturn boolean Was the entity destroyed?
+-- @treturn boolean was the entity destroyed?
 function Entity.destroy_entity( entity, event )
     if entity and entity.valid then
         event = event or {}
@@ -166,9 +167,9 @@ function Entity.destroy_entity( entity, event )
     end
 end
 
---- Create an entity and raise the on_built or on_robot_built event
+--- Create an entity and raise the `on_built` or `on_robot_built` event.
 -- @tparam LuaSurface surface the surface to create the entity on
--- @tparam table settings settings to pass to create_entity  see @{LuaSurface.create_entity}
+-- @tparam table settings settings to pass to create_entity see @{LuaSurface.create_entity}
 -- @tparam[opt] LuaPlayer player If present raise `on_built_entity` with players index, if not present raise `on_robot_built_entity`
 -- @treturn LuaEntity the created entity
 function Entity.create_entity( surface, settings, player )
@@ -188,10 +189,10 @@ function Entity.create_entity( surface, settings, player )
     end
 end
 
---- Revivie an entity ghost and raise the on_built or on_robot_built event
+--- Revivie an entity ghost and raise the `on_built` or `on_robot_built` event.
 -- @tparam LuaEntity ghost the ghost entity to revivie
--- @tparam[opt] LuaPlayer player If present raise `on_built_entity` with players index, if not present raise `on_robot_built_entity`
--- @treturn table Item stacks this entity collided with
+-- @tparam[opt] LuaPlayer player if present, raise `on_built_entity` with players index, if not present raise `on_robot_built_entity`
+-- @treturn table the item stacks this entity collided with
 -- @treturn LuaEntity the new revived entity
 -- @treturn LuaEntity the item request proxy if present
 function Entity.revive(ghost, player)

--- a/stdlib/event/force.lua
+++ b/stdlib/event/force.lua
@@ -1,10 +1,11 @@
 --- Force global creation.
--- Requiring this module will register init and force creation events using the stdlib Event module.
--- All existing and new players will be added to the global.forces table.
--- <br>This module should be first required after any other Init functions but before any scripts needing global.players
--- <br>This modules registers these events, on_init, on_configuration_changed, on_force_created
+-- Requiring this module will register init and force creation events using the stdlib @{Event} module.
+-- <p>All existing and new players will be added to the `global.forces` table.
+-- <p>This module should be first required after any other Init functions but before any scripts needing `global.players`.
+-- <p>This module registers the following events: `on_init`, `on_configuration_changed`, `on_player_created`, and `on_player_removed`.
 -- @module Force
--- @usage local Force = require 'stdlib/event/force'
+-- @usage
+-- local Force = require 'stdlib/event/force'
 -- -- The fist time this is required it will register force creation events
 
 local Game = require 'stdlib/game'
@@ -20,29 +21,32 @@ local function new(force_name)
     }
 end
 
---- Get the game.forces[name] and global.forces[name] objects, create the global.forces[name] object if it doesn't exist.
+--- Get `game.forces[name]` & `global.forces[name]`, or create `global.forces[name]` if it doesn't exist.
 -- @tparam string|LuaForce force the force to get data for
--- @treturn LuaForce
--- @treturn table The forces global data
--- @usage local Force = require 'stdlib/event/force'
+-- @treturn LuaForce the force instance
+-- @treturn table the force's global data
+-- @usage
+-- local Force = require 'stdlib/event/force'
 -- local force_name, force_data = Force.get("player")
 -- local force_name, force_data = Force.get(game.forces["player"])
--- --returns data for the force named "player" from either a string or LuaForce object
+-- -- Returns data for the force named "player" from either a string or LuaForce object
 function Force.get(force)
     force = Game.get_force(force)
     Game.fail_if_missing(force, 'force is missing')
     return game.forces[force.name], global.forces[force.name] or Force.init(force.name)
 end
 
---- Merge a copy of the passed data to all forces in global.forces
+--- Merge a copy of the passed data to all forces in `global.forces`.
 -- @tparam table data a table containing variables to merge
--- @usage local data = {a = 'abc', b = 'def'}
+-- @usage
+-- local data = {a = "abc", b = "def"}
 -- Force.add_data_all(data)
 function Force.add_data_all(data)
     table.each(global.forces, function(v) table.merge(v, table.deepcopy(data)) end)
 end
 
---- Init or re-init a force or forces,
+--- Init or re-init a force or forces.
+-- Passing a `nil` event will iterate all existing forces.
 -- @tparam[opt] string|table event table or a string containing force name
 -- @tparam[opt=false] boolean overwrite the force data
 function Force.init(event, overwrite)

--- a/stdlib/event/gui.lua
+++ b/stdlib/event/gui.lua
@@ -63,7 +63,6 @@ function Gui.dispatch(event)
     end
 end
 
-
 --- Removes the handler with matching gui element pattern from the event.
 -- @tparam defines.events event_id valid values are `defines.events.on_gui_*` from @{defines.events}
 -- @tparam string gui_element_pattern the name or string regular expression for a handler to remove
@@ -87,7 +86,6 @@ function Gui.remove(event_id, gui_element_pattern)
     return Gui
 end
 
-
 --- Registers a function for a given gui element name or pattern when the element is clicked.
 -- @tparam string gui_element_pattern the name or string regular expression to match the gui element
 -- @tparam function handler the function to call when gui element is clicked
@@ -96,34 +94,34 @@ function Gui.on_click(gui_element_pattern, handler)
     return Gui.register(defines.events.on_gui_click, gui_element_pattern, handler)
 end
 
---- Registers a function for a given gui element name or pattern when the element checked state changes.
--- @tparam string gui_element_pattern the name or string regular expression to match the gui element
--- @tparam function handler the function to call when gui element checked state changes
--- @treturn Gui
+--- Registers a function for a given GUI element name or pattern when the element checked state changes.
+-- @tparam string gui_element_pattern the name or string regular expression to match the GUI element
+-- @tparam function handler the function to call when GUI element checked state changes
+-- @return (<span class="types">@{Gui}</span>)
 function Gui.on_checked_state_changed(gui_element_pattern, handler)
     return Gui.register(defines.events.on_gui_checked_state_changed, gui_element_pattern, handler)
 end
 
---- Registers a function for a given gui element name or pattern when the element text changes.
--- @tparam string gui_element_pattern the name or string regular expression to match the gui element
--- @tparam function handler the function to call when gui element text changes
--- @treturn Gui
+--- Registers a function for a given GUI element name or pattern when the element text changes.
+-- @tparam string gui_element_pattern the name or string regular expression to match the GUI element
+-- @tparam function handler the function to call when GUI element text changes
+-- @return (<span class="types">@{Gui}</span>)
 function Gui.on_text_changed(gui_element_pattern, handler)
     return Gui.register(defines.events.on_gui_text_changed, gui_element_pattern, handler)
 end
 
---- Registers a function for a given gui element name or pattern when the element selection changes.
--- @tparam string gui_element_pattern the name or string regular expression to match the gui element
--- @tparam function handler the function to call when gui element selection changes
--- @treturn Gui
+--- Registers a function for a given GUI element name or pattern when the element selection changes.
+-- @tparam string gui_element_pattern the name or string regular expression to match the GUI element
+-- @tparam function handler the function to call when GUI element selection changes
+-- @return (<span class="types">@{Gui}</span>)
 function Gui.on_elem_changed(gui_element_pattern, handler)
     return Gui.register(defines.events.on_gui_elem_changed, gui_element_pattern, handler)
 end
 
---- Registers a function for a given gui element name or pattern when the element state changes (dropdown).
--- @tparam string gui_element_pattern the name or string regular expression to match the gui element
--- @tparam function handler the function to call when gui element state changes
--- @treturn Gui
+--- Registers a function for a given GUI element name or pattern when the element state changes (dropdown).
+-- @tparam string gui_element_pattern the name or string regular expression to match the GUI element
+-- @tparam function handler the function to call when GUI element state changes
+-- @return (<span class="types">@{Gui}</span>)
 function Gui.on_selection_state_changed(gui_element_pattern, handler)
     return Gui.register(defines.events.on_gui_selection_state_changed, gui_element_pattern, handler)
 end

--- a/stdlib/event/player.lua
+++ b/stdlib/event/player.lua
@@ -1,10 +1,11 @@
 --- Player global creation.
--- Requiring this module will register init and player creation events using the stdlib Event module.
--- All existing and new players will be added to the global.players table.
--- <br>This module should be first required after any other Init functions but before any scripts needing global.players
--- <br>Registers on_init, on_configuration_changed, on_player_created, on_player_removed
+-- Requiring this module will register init and player creation events using the stdlib @{Event} module.
+-- <p>All existing and new players will be added to the `global.players` table.
+-- <p>This module should be first required after any other Init functions but before any scripts needing `global.players`.
+-- <p>This module registers the following events: `on_init`, `on_configuration_changed`, `on_player_created`, and `on_player_removed`.
 -- @module Player
--- @usage local Player = require 'stdlib/event/player'
+-- @usage
+-- local Player = require 'stdlib/event/player'
 -- -- The fist time this module is required it will register player creation events
 
 local Game = require 'stdlib/game'
@@ -20,11 +21,12 @@ local function new(player_index)
     }
 end
 
---- Get the game.players[index] and global.players[index] objects, create the global.players[index] object if it doesn't exist.
+--- Get `game.players[index]` & `global.players[index]`, or create `global.players[index]` if it doesn't exist.
 -- @tparam number|string|LuaPlayer player the player index to get data for
--- @treturn LuaPlayer
--- @treturn table The players global data
--- @usage local Player = require 'stdlib/event/player'
+-- @treturn LuaPlayer the player instance
+-- @treturn table the player's global data
+-- @usage
+-- local Player = require 'stdlib/event/player'
 -- local player, player_data = Player.get(event.player_index)
 function Player.get(player)
     player = Game.get_player(player)
@@ -32,7 +34,7 @@ function Player.get(player)
     return game.players[player.index], global.players[player.index] or Player.init(player.index)
 end
 
---- Merge a copy of the passed data to all players in global.players
+--- Merge a copy of the passed data to all players in `global.players`.
 -- @tparam table data a table containing variables to merge
 -- @usage local data = {a = 'abc', b= 'def'}
 -- Player.add_data_all(data)
@@ -41,8 +43,8 @@ function Player.add_data_all(data)
     table.each(pdata, function(v) table.merge(v, table.deepcopy(data)) end)
 end
 
---- Remove data for a player when they are deleted
--- @tparam table event event table containing the player_index
+--- Remove data for a player when they are deleted.
+-- @tparam table event event table containing the `player_index`
 function Player.remove(event)
     local player = Game.get_player(event)
     if player then
@@ -51,7 +53,8 @@ function Player.remove(event)
 end
 Event.register(defines.events.on_player_removed, Player.remove)
 
---- Init or re-init a player or players, Passing a nil event will iterate all existing players
+--- Init or re-init a player or players.
+-- Passing a `nil` event will iterate all existing players.
 -- @tparam[opt] number|table|string|LuaPlayer event
 -- @tparam[opt=false] boolean overwrite the player data
 function Player.init(event, overwrite)

--- a/stdlib/utils/console.lua
+++ b/stdlib/utils/console.lua
@@ -1,9 +1,10 @@
 --- Debug console.
--- Creates a textfield allowing you to run commands directly in your mods enviorment.
--- <br>Requires use of the stdlib event system for gui interaction.
--- <br>Console Code from adil modified for use with stdlib.
+-- Creates a textfield allowing you to run commands directly in your mod's enviorment.
+-- <p>This module requires the use of stdlib's @{Event} module for GUI interactions.
+-- <p>This module was originally the ***Console*** code from a modder named ***adil***, which has been modified for use with stdlib.
 -- @module Console
--- @usage remote.add_interface("my_interface", {show=require('stdlib/utils/console')})
+-- @usage
+-- remote.add_interface("my_interface", {show = require("stdlib/utils/console")})
 -- /c remote.call("my_interface", "show", game.player)
 -- --In the window that appears you can run lua code directly on your mod, including globals.
 
@@ -61,7 +62,6 @@ local function create_gui(player)
         create_gui_player(player)
     end
 end
-
 
 local function enter(event)
     local p = game.players[event.player_index]


### PR DESCRIPTION
@Nexela @Afforess 

Thanks, Nexela for the work on the World simulator and pointing me in the right direction with opened spec test cases.

Created the test cases for important and prominent areas in the module.

**Three test scenarios** were core to `stdlib.event.opened`:

1. Test that `global._opened_guis` initializes on `Event.core_events.init_and_config`.
2. Test that `raise_opened_closed_events` & `create_globals` successfully register to their respective events.
3. Test that ***all four*** `script.raise_event` calls get called under their respective conditions **AND** that we receive the correct `event data` table in the registered handlers when the events are raised.

Please feel free to leave any comments for any issues with the code or if you find anything that I missed or if you think certain parts need any refactoring.