### PR TITLE
Data library patch recipes

### DIFF
--- a/stdlib/data/data.lua
+++ b/stdlib/data/data.lua
@@ -228,17 +228,31 @@ function Data.new_sound(name, file)
     }
 end
 
+local function subgroup_order(data, subgroup, order)
+    data.subgroup = subgroup and #subgroup > 0 and subgroup or data.subgroup
+    data.order = order and #order > 0 and order or data.order
+end
+
 --- Change subroup and/or order
 -- @tparam string data_type
 -- @tparam string name
 -- @tparam string subgroup
 -- @tparam string order
-function Data.subgroup_order(data_type, name, subgroup, order)
+function Data.subgroup_order_from(data_type, name, subgroup, order)
     local data = data.raw[data_type] and data.raw[data_type][name]
     if data then
-        data.subgroup = subgroup and #subgroup > 0 and subgroup or data.subgroup
-        data.order = order and #order > 0 and order or data.order
+        subgroup_order(data, subgroup, order)
     end
+end
+
+local function replace_icon(data, icon, size)
+    if type(icon) == "table" then
+        data.icons = icon
+        data.icon = nil
+    else
+        data.icon = icon
+    end
+    data.icon_size = size or data.icon_size
 end
 
 --- Replace an icon
@@ -246,31 +260,33 @@ end
 -- @tparam string name
 -- @tparam string icon
 -- @tparam int size
-function Data.replace_icon(data_type, name, icon, size)
+function Data.replace_icon_from(data_type, name, icon, size)
     local data = data.raw[data_type] and data.raw[data_type][name]
     if data then
-        if type(icon) == "table" then
-            data.icons = icon
-            data.icon = nil
-        else
-            data.icon = icon
-            data.icon_size = size or data.icon_size
-        end
+        replace_icon(data, icon, size)
     end
+end
+
+local function get_icons(data, copy)
+    return copy and table.deepcopy(data.icons) or data.icons
 end
 
 --- Get the icons
 -- @tparam string data_type
 -- @tparam string name
 -- @tparam boolean copy
-function Data.get_icons(data_type, name, copy)
+function Data.get_icons_from(data_type, name, copy)
     local data = data.raw[data_type] and data.raw[data_type][name]
-    return data and copy and table.deepcopy(data.icons) or data and data.icons
+    return data and get_icons(data, copy)
 end
 
-function Data.get_icon(data_type, name)
+local function get_icon(data)
+    return data.icon
+end
+
+function Data.get_icon_from(data_type, name)
     local data = data.raw[data_type] and data.raw[data_type][name]
-    return data and data.icon
+    return data and get_icon(data)
 end
 
 --[Classes]--------------------------------------------------------------------
@@ -387,6 +403,43 @@ function Data:set_fields(tab)
         for k, v in pairs(tab) do
             rawset(self, k, v)
         end
+    end
+    return self
+end
+
+--- Change subroup and/or order
+-- @tparam string subgroup
+-- @tparam string order
+function Data:subgroup_order(subgroup, order)
+    if self:valid() then
+        subgroup_order(self, subgroup, order)
+    end
+    return self
+end
+
+--- Replace an icon
+-- @tparam string icon
+-- @tparam int size
+function Data:replace_icon(icon, size)
+    if self:valid() then
+        replace_icon(self, icon, size)
+    end
+    return self
+end
+
+--- Get the icons
+-- @tparam string data_type
+-- @tparam string name
+-- @tparam boolean copy
+function Data:get_icons(copy)
+    if self:valid() then
+        return get_icons(self, copy)
+    end
+end
+
+function Data:get_icon()
+    if self:valid() then
+        return get_icon(self)
     end
 end
 

--- a/stdlib/data/recipe.lua
+++ b/stdlib/data/recipe.lua
@@ -82,6 +82,7 @@ end
 -- @tparam table ingredients
 -- @tparam string name Name of the ingredient to remove
 local function remove_ingredient(ingredients, name)
+    name = name.name
     for i, ingredient in pairs(ingredients) do
         if ingredient[1] == name or ingredient.name == name then
             ingredients[i] = nil

--- a/stdlib/data/technology.lua
+++ b/stdlib/data/technology.lua
@@ -52,8 +52,7 @@ function Technology:add_effect(effect, unlock_type)
     self.fail_if_missing(effect)
 
     --todo fix for non recipe types
-    local add_unlock =
-        function(technology, name)
+    local add_unlock = function(technology, name)
         local effects = technology.effects
         effects[#effects + 1] = {
             type = unlock_type,
@@ -65,12 +64,10 @@ function Technology:add_effect(effect, unlock_type)
         local Recipe = require("stdlib/data/recipe")
         unlock_type = (not unlock_type and "unlock-recipe") or unlock_type
         local r_name = type(effect) == "table" and effect.name or effect
-        if unlock_type == "unlock-recipe" then
+        if unlock_type == "unlock-recipe" or not unlock_type then
             if Recipe(effect):valid() then
                 add_unlock(self, r_name)
             end
-        else
-            add_unlock(self, r_name)
         end
     elseif self:valid("recipe") then
         unlock_type = "unlock-recipe"
@@ -96,7 +93,7 @@ function Technology:remove_effect(tech_name, unlock_type, name)
         if tech_name then
             local tech = Technology(tech_name):valid()
             if tech then
-                for index, effect in pairs(tech.effects) do
+                for index, effect in pairs(tech.effects or {}) do
                     if effect.type == "unlock-recipe" and effect.recipe == self.name then
                         table.remove(tech.effects, index)
                     end
@@ -104,7 +101,7 @@ function Technology:remove_effect(tech_name, unlock_type, name)
             end
         else
             for _, tech in pairs(data.raw["technology"]) do
-                for index, effect in pairs(tech.effects) do
+                for index, effect in pairs(tech.effects or {}) do
                     if effect.type == "unlock-recipe" and effect.recipe == self.name then
                         table.remove(tech.effects, index)
                     end


### PR DESCRIPTION
Fixed two bugs, one of them even crashed on the basegame!
* Technology:remove_effect crashed on effect-less recipes
* Technology:add_effect always added a unlock-recipe effect (added fail-safe behaviour)

Also apparently the previous PR is here too? -_-