### PR TITLE
Surface.set daytime thresholds

### DIFF
--- a/spec/area/surface_spec.lua
+++ b/spec/area/surface_spec.lua
@@ -33,4 +33,12 @@ describe('Surface Spec', function()
             assert.same({ game.surfaces['nauvis'] }, Surface.lookup({ game.surfaces['nauvis'] }))
         end)
     end)
+
+    describe('Surface set daytime thresholds', function()
+        it('should fail with no parameters', function()
+            assert.falsy(pcall(Surface.set_daytime_thresholds))
+        end)
+        -- TODO reproduce dusk<=evening<=morning<=dawn check and assertions for testing
+    end)
+
 end)

--- a/stdlib/area/surface.lua
+++ b/stdlib/area/surface.lua
@@ -122,4 +122,29 @@ function Surface.get_surface_bounds(surface)
     return Area.construct(x1*32, y1*32, x2*32, y2*32)
 end
 
+--- Sets the daytime transition thresholds on a given surface
+-- @tparam LuaSurface surface the surface for which to set the thresholds
+-- @tparam float morning daytime to begin transition from dark to light
+-- @tparam float dawn daytime to finish transition from dark to light
+-- @tparam float dusk daytime to begin transition from light to dark
+-- @tparam float evening daytime to finish transition from light to dark
+-- @treturn boolean true if the thresholds were set, false if there was an error
+-- @return[opt] the raised error, if any
+function Surface.set_daytime_thresholds(surface, morning, dawn, dusk, evening)
+    Game.fail_if_missing(surface, 'missing surface value')
+
+    -- wrapped in pcall because the game considers not(dusk<evening<morning<dawn) a game ending exception
+    return pcall(
+        function ()
+            surface.dusk = 0
+            surface.evening = .0000000001
+            surface.morning = .0000000002
+            surface.dawn = dawn
+            surface.morning = morning
+            surface.evening = evening
+            surface.dusk = dusk
+        end
+    )
+end
+
 return setmetatable(Surface, Game._protect("Surface"))


### PR DESCRIPTION
Testing this is going to require mocking the part of LuaSurface that asserts dusk<evening<morning<dawn on assigment, which requires more metatable trickery than I could conjure up tonight.

More manual testing is required, I just wanted to put this here in case more eyes will help.