### PR TITLE
Added remove_ingredient to add_ingredient

### DIFF
--- a/stdlib/data/recipe.lua
+++ b/stdlib/data/recipe.lua
@@ -100,7 +100,8 @@ end
 function Recipe:add_ingredient(normal, expensive)
     if self:is_valid() then
         normal, expensive = get_difficulties(normal, expensive)
-
+        self:remove_ingredient (normal, expensive)
+        
         if self.normal then
             if normal then
                 self.normal.ingredients = self.normal.ingredients or {}


### PR DESCRIPTION
When adding ingredients, it WILL crash the game if duplicate entries exist, under most circumstances.
The quick and dirty fix is to remove it before adding it, a more complicated check would involve looking for it and updating an existing entry instead.

I just added the remove_ingredient so that the function is at least usable.